### PR TITLE
Make `CArray` & `CIndexer` on host variable-sized structs

### DIFF
--- a/cupy/_core/_carray.pxd
+++ b/cupy/_core/_carray.pxd
@@ -1,4 +1,5 @@
 cimport cython  # NOQA
+from libc.stdint cimport intptr_t
 from libcpp cimport vector
 
 from cupy.cuda cimport function
@@ -21,9 +22,6 @@ cdef struct _CArray:
 @cython.final
 cdef class CArray(function.CPointer):
 
-    cdef:
-        object val
-
     cdef void init(
         self, void* data_ptr, Py_ssize_t data_size,
         const shape_t& shape, const strides_t& strides) except*
@@ -35,8 +33,6 @@ cdef struct _CIndexer:
 
 
 cdef class CIndexer(function.CPointer):
-    cdef:
-        object val
 
     cdef void init(self, Py_ssize_t size, const shape_t &shape) except*
 

--- a/cupy/_core/_carray.pxd
+++ b/cupy/_core/_carray.pxd
@@ -12,31 +12,31 @@ ctypedef vector.vector[Py_ssize_t] strides_t
 cdef enum: MAX_NDIM = 64
 
 
+# This is now excluding shape/strides only for getting the compiler-time size
 cdef struct _CArray:
     void* data
     Py_ssize_t size
-    Py_ssize_t shape_and_strides[MAX_NDIM * 2]
 
 
 @cython.final
 cdef class CArray(function.CPointer):
 
     cdef:
-        _CArray val
+        object val
 
     cdef void init(
         self, void* data_ptr, Py_ssize_t data_size,
         const shape_t& shape, const strides_t& strides) except*
 
 
+# This is now excluding shape/strides only for getting the compiler-time size
 cdef struct _CIndexer:
     Py_ssize_t size
-    Py_ssize_t shape_and_index[MAX_NDIM * 2]
 
 
 cdef class CIndexer(function.CPointer):
     cdef:
-        _CIndexer val
+        object val
 
     cdef void init(self, Py_ssize_t size, const shape_t &shape) except*
 


### PR DESCRIPTION
We relax the struct sizes so that the last member size varies based on `.ndim` instead of being fixed at `MAX_NDIM`. This reduces the kernel argument sizes significantly. This actually works fine because the driver knows exactly the number of bytes to copy based on the device-side (not host-side) `CArray`/`CIndexer` template instantiations (which is based on `.ndim`).  

Right now, the dynamic storage is conveniently provided by ~~using NumPy structured arrays, but we don't have to do so, given that we aim to support finite `MAX_NDIM`, in which case we can turn the singleton struct `_CArray` into 65 predefined storage classes `cdef class _CArray_<N>` for N=0, 1, 2, ..., 64, and dynamically choose which class to use at run time.~~ **UPDATE**: packing a buffer manually based on the same memory layout as `CArray` on the device side. 

TODO:
- [x] Perf benchmark 